### PR TITLE
Fixing control channel to use frames.

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -90,9 +90,11 @@ func TestConnection(t *testing.T) {
 				m.Lock()
 				defer m.Unlock()
 				conn.SetWriteDeadline(time.Now().Add(2 * time.Second))
-				if err := conn.WriteJSON(&uspControlMessage{
-					Verb: uspControlMessageRECONNECT,
-				}); err != nil {
+				if err := conn.WriteJSON(frame{
+					ModuleID: moduleIDUSP,
+					Messages: []interface{}{&uspControlMessage{
+						Verb: uspControlMessageRECONNECT,
+					}}}); err != nil {
 					fmt.Printf("WriteJSON(): %v\n", err)
 					return
 				}
@@ -118,10 +120,12 @@ func TestConnection(t *testing.T) {
 				if uMsg.AckRequested {
 					m.Lock()
 					conn.SetWriteDeadline(time.Now().Add(2 * time.Second))
-					if err := conn.WriteJSON(&uspControlMessage{
-						Verb:   uspControlMessageACK,
-						SeqNum: uMsg.SeqNum,
-					}); err != nil {
+					if err := conn.WriteJSON(frame{
+						ModuleID: moduleIDUSP,
+						Messages: []interface{}{&uspControlMessage{
+							Verb:   uspControlMessageACK,
+							SeqNum: uMsg.SeqNum,
+						}}}); err != nil {
 						fmt.Printf("WriteJSON(): %v\n", err)
 						m.Unlock()
 						return


### PR DESCRIPTION
## Description of the change

Make the receive path of control messages use frames as well.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

