### PR TITLE
Missing a clear of the stop flag.

### DIFF
--- a/client.go
+++ b/client.go
@@ -167,6 +167,7 @@ func (c *Client) connect() error {
 		c.setLastError(err)
 		return err
 	}
+	c.isStop.Clear()
 	c.conn = conn
 	c.wg.Add(1)
 	go func() {


### PR DESCRIPTION
## Description of the change

Fixing bug where goroutines would stop on reconnect.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


