### PR TITLE
Increase the timeout on send to 30s.

### DIFF
--- a/client.go
+++ b/client.go
@@ -204,8 +204,11 @@ func (c *Client) disconnect() error {
 	c.isStop.Set()
 	c.connMutex.Lock()
 	defer c.connMutex.Unlock()
-	c.conn.WriteControl(websocket.CloseMessage, []byte{}, time.Now().Add(5*time.Second))
-	err := c.conn.Close()
+	var err error
+	if c.conn != nil {
+		c.conn.WriteControl(websocket.CloseMessage, []byte{}, time.Now().Add(5*time.Second))
+		err = c.conn.Close()
+	}
 	c.wg.Wait()
 	c.conn = nil
 	if err != nil {

--- a/client.go
+++ b/client.go
@@ -352,7 +352,7 @@ func (c *Client) sender() {
 			}
 		}
 
-		c.conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+		c.conn.SetWriteDeadline(time.Now().Add(30 * time.Second))
 		if err := c.conn.WriteMessage(websocket.BinaryMessage, b.Bytes()); err != nil {
 			c.onWarning(fmt.Sprintf("timeout sending data, reconnecting: %v", err))
 			c.setLastError(err)


### PR DESCRIPTION
## Description of the change

Increase the timeout on send to 30s to account for slower networks or larger payloads.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

