### PR TITLE
Increase control receive timeout since it's not a keepalive.

### DIFF
--- a/client.go
+++ b/client.go
@@ -272,7 +272,7 @@ func (c *Client) listener() {
 
 	for !c.isStop.IsSet() {
 		msg := protocol.ControlMessage{}
-		c.conn.SetReadDeadline(time.Now().Add(60 * time.Minute))
+		c.conn.SetReadDeadline(time.Now().Add(24*time.Hour))
 		if err := c.conn.ReadJSON(&msg); err != nil {
 			c.onWarning(err.Error())
 			c.setLastError(err)


### PR DESCRIPTION
## Description of the change

The control messages are no longer used as keepalives so it doesn't make sense to have a 1h timeout.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


