### PR TITLE
Increase keepalive timeout to go with blocking writes.

### DIFF
--- a/client.go
+++ b/client.go
@@ -375,7 +375,7 @@ func (c *Client) keepAliveSender() {
 			return
 		}
 
-		if err := c.conn.WriteControl(websocket.PingMessage, []byte{}, time.Now().Add(5*time.Second)); err != nil {
+		if err := c.conn.WriteControl(websocket.PingMessage, []byte{}, time.Now().Add(45*time.Second)); err != nil {
 			c.onWarning(fmt.Sprintf("keepalive failed, reconnecting: %v", err))
 			c.setLastError(err)
 			c.Reconnect()

--- a/client.go
+++ b/client.go
@@ -375,7 +375,7 @@ func (c *Client) keepAliveSender() {
 			return
 		}
 
-		if err := c.conn.WriteControl(websocket.PingMessage, []byte{}, time.Now().Add(45*time.Second)); err != nil {
+		if err := c.conn.WriteControl(websocket.PingMessage, []byte{}, time.Now().Add(2 * time.Minute)); err != nil {
 			c.onWarning(fmt.Sprintf("keepalive failed, reconnecting: %v", err))
 			c.setLastError(err)
 			c.Reconnect()


### PR DESCRIPTION
## Description of the change

During heavy transfers, keepalive might take a while.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


