### PR TITLE
Increase Write timeouts to avoid timeout during heavy flow control.

### DIFF
--- a/client.go
+++ b/client.go
@@ -362,7 +362,7 @@ func (c *Client) sender() {
 			}
 		}
 
-		c.conn.SetWriteDeadline(time.Now().Add(1 * time.Minute))
+		c.conn.SetWriteDeadline(time.Now().Add(30 * time.Minute))
 		if err := c.conn.WriteMessage(websocket.BinaryMessage, b.Bytes()); err != nil {
 			c.onWarning(fmt.Sprintf("timeout sending data, reconnecting: %v", err))
 			c.setLastError(err)
@@ -382,7 +382,7 @@ func (c *Client) keepAliveSender() {
 			return
 		}
 
-		if err := c.conn.WriteControl(websocket.PingMessage, []byte{}, time.Now().Add(2*time.Minute)); err != nil {
+		if err := c.conn.WriteControl(websocket.PingMessage, []byte{}, time.Now().Add(30*time.Minute)); err != nil {
 			c.onWarning(fmt.Sprintf("keepalive failed, reconnecting: %v", err))
 			c.setLastError(err)
 			c.Reconnect()


### PR DESCRIPTION
## Description of the change

Bump the write timeouts way up to reduce the possibility of timeouts during backoff.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

