### PR TITLE
Adding an instance ID field to conn headers.

### DIFF
--- a/client.go
+++ b/client.go
@@ -17,6 +17,8 @@ import (
 	"github.com/refractionPOINT/go-uspclient/protocol"
 
 	"github.com/vmihailenco/msgpack/v5"
+
+	"github.com/google/uuid"
 )
 
 type Client struct {
@@ -35,6 +37,8 @@ type Client struct {
 
 	lastError  error
 	errorMutex sync.Mutex
+
+	instanceID string
 }
 
 type Identity struct {
@@ -110,6 +114,7 @@ func NewClient(o ClientOptions) (*Client, error) {
 		isStop:  NewEvent(),
 		isStart: NewEvent(),
 	}
+	c.instanceID = uuid.NewString()
 	if err := c.connect(); err != nil {
 		return nil, err
 	}
@@ -155,6 +160,7 @@ func (c *Client) connect() error {
 		SensorSeedKey:   c.options.SensorSeedKey,
 		IsCompressed:    c.options.IsCompressed,
 		DataFormat:      "msgpack",
+		InstanceID:      c.instanceID,
 	}); err != nil {
 		c.onWarning(fmt.Sprintf("WriteJSON(): %v", err))
 		conn.WriteControl(websocket.CloseMessage, []byte{}, time.Now().Add(5*time.Second))

--- a/protocol/auth.go
+++ b/protocol/auth.go
@@ -15,4 +15,5 @@ type ConnectionHeader struct {
 	SensorSeedKey   string            `json:"sensor_seed_key"`
 	IsCompressed    bool              `json:"is_compressed"`
 	DataFormat      string            `json:"data_format"` // LimaCharlie supports "msgpack" or "json"
+	InstanceID      string            `json:"instance_id"`
 }


### PR DESCRIPTION
## Description of the change

Adding an instance id field to the connection headers. This field is used as a hint to LimaCharlie about the state continuation of the client.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

