### PR TITLE
Remove old pre-move sensor-key-path.

### DIFF
--- a/client.go
+++ b/client.go
@@ -57,7 +57,6 @@ type ClientOptions struct {
 	BufferOptions AckBufferOptions           `json:"buffer_options,omitempty" yaml:"buffer_options,omitempty"`
 	IsCompressed  bool                       `json:"is_compressed,omitempty" yaml:"is_compressed,omitempty"`
 
-	SensorKeyPath string `json:"sensor_key_path" yaml:"sensor_key_path"`
 	SensorSeedKey string `json:"sensor_seed_key" yaml:"sensor_seed_key"`
 
 	DebugLog  func(string) `json:"-" yaml:"-"`


### PR DESCRIPTION
## Description of the change

Removing old field. The Sensor Key Path was moved to the Mapping section.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


