### PR TITLE
Avoid a race while receiving data.

### DIFF
--- a/client.go
+++ b/client.go
@@ -294,12 +294,15 @@ func (c *Client) Reconnect() {
 	if !atomic.CompareAndSwapUint32(&c.isReconnecting, 0, 1) {
 		return
 	}
-	c.ab.UpdateCapacity(1)
+
 	go func() {
 		if err := c.disconnect(); err != nil {
 			c.setLastError(err)
 			c.onWarning(fmt.Sprintf("error disconnecting: %v", err))
 		}
+
+		// Start the window size back to 1.
+		c.ab.UpdateCapacity(1)
 
 		// We assume that anything that was not ACKed should be resent
 		c.ab.ResetDelivery()


### PR DESCRIPTION
## Description of the change

Small tweak to reset the AckBuffer more synchronously.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
