### PR TITLE
Add HTTP CONNECT proxy support for LimaCharlie connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,30 @@ options := uspclient.ClientOptions{
     Platform: "your-platform",
     
     // Proxy configuration
+    Proxy: uspclient.ProxyOptions{
+        URL:      "http://proxy.example.com:8080",
+        Username: "username",  // optional
+        Password: "password",  // optional
+        
+        // Optional timeout configurations (with defaults)
+        HandshakeTimeout: 45 * time.Second,  // WebSocket handshake timeout
+        ConnectTimeout:   10 * time.Second,  // Proxy connection timeout
+        ReadWriteTimeout: 30 * time.Second,  // Proxy read/write timeout
+    },
+}
+```
+
+For backward compatibility, the following deprecated fields are still supported:
+```go
+options := uspclient.ClientOptions{
+    // ... other options ...
+    
+    // Deprecated: Use Proxy.URL instead
     ProxyURL:      "http://proxy.example.com:8080",
-    ProxyUsername: "username",  // optional
-    ProxyPassword: "password",  // optional
+    // Deprecated: Use Proxy.Username instead
+    ProxyUsername: "username",
+    // Deprecated: Use Proxy.Password instead
+    ProxyPassword: "password",
 }
 ```
 
@@ -34,10 +55,12 @@ The proxy settings support:
 - HTTP Basic authentication
 - Automatic retry (3 attempts) on proxy connection failures
 - Proper TLS/SSL negotiation through the proxy
+- Configurable timeouts for different phases of the connection
 
 ### Validation
 The client validates proxy configuration during initialization:
 - Proxy URL must be valid if provided
+- Proxy URL must not contain credentials (use separate username/password fields)
 - If authentication is used, both username and password must be provided
 
 ## Protocol

--- a/README.md
+++ b/README.md
@@ -36,20 +36,6 @@ options := uspclient.ClientOptions{
 }
 ```
 
-For backward compatibility, the following deprecated fields are still supported:
-```go
-options := uspclient.ClientOptions{
-    // ... other options ...
-    
-    // Deprecated: Use Proxy.URL instead
-    ProxyURL:      "http://proxy.example.com:8080",
-    // Deprecated: Use Proxy.Username instead
-    ProxyUsername: "username",
-    // Deprecated: Use Proxy.Password instead
-    ProxyPassword: "password",
-}
-```
-
 The proxy settings support:
 - HTTP CONNECT tunneling for WebSocket connections
 - HTTP Basic authentication

--- a/README.md
+++ b/README.md
@@ -1,6 +1,45 @@
 # go-uspclient
 Golang USP Client
 
+## Features
+- WebSocket-based communication with LimaCharlie cloud
+- Automatic flow control and message acknowledgment
+- Built-in compression support
+- HTTP CONNECT proxy support for restricted networks
+- Flexible event mapping and transformation
+
+## Proxy Support
+The USP client supports connecting to LimaCharlie cloud through HTTP CONNECT proxies. This is useful in enterprise environments where direct internet access is restricted.
+
+### Configuration
+Add proxy settings to your `ClientOptions`:
+
+```go
+options := uspclient.ClientOptions{
+    Identity: uspclient.Identity{
+        Oid:             "your-org-id",
+        InstallationKey: "your-key",
+    },
+    Platform: "your-platform",
+    
+    // Proxy configuration
+    ProxyURL:      "http://proxy.example.com:8080",
+    ProxyUsername: "username",  // optional
+    ProxyPassword: "password",  // optional
+}
+```
+
+The proxy settings support:
+- HTTP CONNECT tunneling for WebSocket connections
+- HTTP Basic authentication
+- Automatic retry (3 attempts) on proxy connection failures
+- Proper TLS/SSL negotiation through the proxy
+
+### Validation
+The client validates proxy configuration during initialization:
+- Proxy URL must be valid if provided
+- If authentication is used, both username and password must be provided
+
 ## Protocol
 USP is based on a secure websocket connection to the relevant LimaCharlie datacenter and is formatted in JSON.
 

--- a/client.go
+++ b/client.go
@@ -89,32 +89,9 @@ type ClientOptions struct {
 
 	// Proxy configuration for connecting to LimaCharlie cloud
 	Proxy ProxyOptions `json:"proxy,omitempty" yaml:"proxy,omitempty"`
-
-	// Deprecated: Use Proxy.URL instead
-	ProxyURL string `json:"proxy_url,omitempty" yaml:"proxy_url,omitempty"`
-	// Deprecated: Use Proxy.Username instead
-	ProxyUsername string `json:"proxy_username,omitempty" yaml:"proxy_username,omitempty"`
-	// Deprecated: Use Proxy.Password instead
-	ProxyPassword string `json:"proxy_password,omitempty" yaml:"proxy_password,omitempty"`
 }
 
 func (o *ClientOptions) normalizeProxyConfig() {
-	// Handle backward compatibility - migrate deprecated fields to new structure
-	if o.Proxy.URL == "" && o.ProxyURL != "" {
-		o.Proxy.URL = o.ProxyURL
-	}
-	if o.Proxy.Username == "" && o.ProxyUsername != "" {
-		o.Proxy.Username = o.ProxyUsername
-	}
-	if o.Proxy.Password == "" && o.ProxyPassword != "" {
-		o.Proxy.Password = o.ProxyPassword
-	}
-	
-	// Always clear deprecated fields after migration
-	o.ProxyURL = ""
-	o.ProxyUsername = ""
-	o.ProxyPassword = ""
-
 	// Set default timeouts if not specified
 	if o.Proxy.HandshakeTimeout == 0 {
 		o.Proxy.HandshakeTimeout = 45 * time.Second
@@ -139,13 +116,8 @@ func (o ClientOptions) Validate() error {
 	}
 
 	// Validate proxy configuration if provided
-	proxyURL := o.Proxy.URL
-	if proxyURL == "" {
-		proxyURL = o.ProxyURL // Check deprecated field too
-	}
-	
-	if proxyURL != "" {
-		parsedURL, err := url.Parse(proxyURL)
+	if o.Proxy.URL != "" {
+		parsedURL, err := url.Parse(o.Proxy.URL)
 		if err != nil {
 			return fmt.Errorf("invalid proxy URL: %v", err)
 		}
@@ -156,16 +128,7 @@ func (o ClientOptions) Validate() error {
 		}
 		
 		// Check authentication completeness
-		username := o.Proxy.Username
-		password := o.Proxy.Password
-		if username == "" {
-			username = o.ProxyUsername // Check deprecated field
-		}
-		if password == "" {
-			password = o.ProxyPassword // Check deprecated field
-		}
-		
-		if (username != "" && password == "") || (username == "" && password != "") {
+		if (o.Proxy.Username != "" && o.Proxy.Password == "") || (o.Proxy.Username == "" && o.Proxy.Password != "") {
 			return errors.New("proxy authentication requires both username and password")
 		}
 	}

--- a/client.go
+++ b/client.go
@@ -15,7 +15,6 @@ import (
 	"net/url"
 	"os"
 	"regexp"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"

--- a/client_proxy_test.go
+++ b/client_proxy_test.go
@@ -1,0 +1,321 @@
+package uspclient
+
+import (
+	"bufio"
+	"context"
+	"encoding/base64"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+)
+
+// mockProxyServer creates a simple HTTP CONNECT proxy for testing
+type mockProxyServer struct {
+	listener net.Listener
+	addr     string
+	username string
+	password string
+	t        *testing.T
+}
+
+func newMockProxyServer(t *testing.T, username, password string) (*mockProxyServer, error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, err
+	}
+
+	proxy := &mockProxyServer{
+		listener: listener,
+		addr:     listener.Addr().String(),
+		username: username,
+		password: password,
+		t:        t,
+	}
+
+	go proxy.serve()
+	return proxy, nil
+}
+
+func (p *mockProxyServer) serve() {
+	for {
+		conn, err := p.listener.Accept()
+		if err != nil {
+			return
+		}
+		go p.handleConnection(conn)
+	}
+}
+
+func (p *mockProxyServer) handleConnection(conn net.Conn) {
+	defer conn.Close()
+
+	reader := bufio.NewReader(conn)
+	request, err := http.ReadRequest(reader)
+	if err != nil {
+		p.t.Logf("Failed to read request: %v", err)
+		return
+	}
+
+	if request.Method != "CONNECT" {
+		conn.Write([]byte("HTTP/1.1 405 Method Not Allowed\r\n\r\n"))
+		return
+	}
+
+	// Check authentication if required
+	if p.username != "" && p.password != "" {
+		authHeader := request.Header.Get("Proxy-Authorization")
+		expectedAuth := "Basic " + basicAuth(p.username, p.password)
+		if authHeader != expectedAuth {
+			conn.Write([]byte("HTTP/1.1 407 Proxy Authentication Required\r\n\r\n"))
+			return
+		}
+	}
+
+	// Simulate successful CONNECT
+	conn.Write([]byte("HTTP/1.1 200 Connection Established\r\n\r\n"))
+
+	// For testing purposes, just echo back any data received
+	buffer := make([]byte, 1024)
+	for {
+		n, err := conn.Read(buffer)
+		if err != nil {
+			return
+		}
+		conn.Write(buffer[:n])
+	}
+}
+
+func (p *mockProxyServer) close() {
+	p.listener.Close()
+}
+
+func (p *mockProxyServer) URL() string {
+	return "http://" + p.addr
+}
+
+func basicAuth(username, password string) string {
+	auth := username + ":" + password
+	return base64.StdEncoding.EncodeToString([]byte(auth))
+}
+
+func TestClientOptions_Validate_ProxyConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		proxyURL    string
+		proxyUser   string
+		proxyPass   string
+		expectError bool
+		errorMsg    string
+	}{
+		{
+			name:        "valid proxy URL",
+			proxyURL:    "http://proxy.example.com:8080",
+			expectError: false,
+		},
+		{
+			name:        "invalid proxy URL",
+			proxyURL:    "://invalid-url",
+			expectError: true,
+			errorMsg:    "invalid proxy URL",
+		},
+		{
+			name:        "proxy with valid auth",
+			proxyURL:    "http://proxy.example.com:8080",
+			proxyUser:   "user",
+			proxyPass:   "pass",
+			expectError: false,
+		},
+		{
+			name:        "proxy with incomplete auth - missing password",
+			proxyURL:    "http://proxy.example.com:8080",
+			proxyUser:   "user",
+			proxyPass:   "",
+			expectError: true,
+			errorMsg:    "proxy authentication requires both username and password",
+		},
+		{
+			name:        "proxy with incomplete auth - missing username",
+			proxyURL:    "http://proxy.example.com:8080",
+			proxyUser:   "",
+			proxyPass:   "pass",
+			expectError: true,
+			errorMsg:    "proxy authentication requires both username and password",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := ClientOptions{
+				Identity: Identity{
+					Oid:             "test-org",
+					InstallationKey: "test-key",
+				},
+				Platform:      "test",
+				ProxyURL:      tt.proxyURL,
+				ProxyUsername: tt.proxyUser,
+				ProxyPassword: tt.proxyPass,
+			}
+
+			err := opts.Validate()
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errorMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestCreateProxyDialer(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupProxy    bool
+		proxyAuth     bool
+		proxyURL      string
+		expectDefault bool
+	}{
+		{
+			name:          "no proxy configured",
+			setupProxy:    false,
+			expectDefault: true,
+		},
+		{
+			name:          "proxy without auth",
+			setupProxy:    true,
+			proxyAuth:     false,
+			expectDefault: false,
+		},
+		{
+			name:          "proxy with auth",
+			setupProxy:    true,
+			proxyAuth:     true,
+			expectDefault: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var proxyURL string
+			var client *Client
+
+			if tt.setupProxy {
+				// Create mock proxy server
+				username := ""
+				password := ""
+				if tt.proxyAuth {
+					username = "testuser"
+					password = "testpass"
+				}
+
+				proxy, err := newMockProxyServer(t, username, password)
+				assert.NoError(t, err)
+				defer proxy.close()
+
+				proxyURL = proxy.URL()
+				client = &Client{
+					options: ClientOptions{
+						ProxyURL:      proxyURL,
+						ProxyUsername: username,
+						ProxyPassword: password,
+					},
+					wssURL: "wss://test.limacharlie.io/test",
+				}
+			} else {
+				client = &Client{
+					options: ClientOptions{},
+					wssURL:  "wss://test.limacharlie.io/test",
+				}
+			}
+
+			dialer, err := client.createProxyDialer()
+			assert.NoError(t, err)
+			assert.NotNil(t, dialer)
+
+			if tt.expectDefault {
+				// When no proxy is configured, should return default dialer
+				assert.Equal(t, websocket.DefaultDialer, dialer)
+			} else {
+				// When proxy is configured, should return custom dialer
+				assert.NotEqual(t, websocket.DefaultDialer, dialer)
+				assert.NotNil(t, dialer.NetDialContext)
+				assert.Nil(t, dialer.Proxy)
+				assert.NotNil(t, dialer.TLSClientConfig)
+			}
+		})
+	}
+}
+
+func TestProxyDialerConnection(t *testing.T) {
+	// Create mock proxy server
+	proxy, err := newMockProxyServer(t, "testuser", "testpass")
+	assert.NoError(t, err)
+	defer proxy.close()
+
+	client := &Client{
+		options: ClientOptions{
+			ProxyURL:      proxy.URL(),
+			ProxyUsername: "testuser",
+			ProxyPassword: "testpass",
+		},
+		wssURL: "wss://test.limacharlie.io/test",
+	}
+
+	dialer, err := client.createProxyDialer()
+	assert.NoError(t, err)
+
+	// Test the NetDialContext function
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	conn, err := dialer.NetDialContext(ctx, "tcp", "test.limacharlie.io:443")
+	assert.NoError(t, err)
+	assert.NotNil(t, conn)
+	conn.Close()
+}
+
+func TestProxyDialerAuthFailure(t *testing.T) {
+	// Create mock proxy server with auth
+	proxy, err := newMockProxyServer(t, "testuser", "testpass")
+	assert.NoError(t, err)
+	defer proxy.close()
+
+	client := &Client{
+		options: ClientOptions{
+			ProxyURL:      proxy.URL(),
+			ProxyUsername: "wronguser",
+			ProxyPassword: "wrongpass",
+		},
+		wssURL: "wss://test.limacharlie.io/test",
+	}
+
+	dialer, err := client.createProxyDialer()
+	assert.NoError(t, err)
+
+	// Test the NetDialContext function with wrong credentials
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	conn, err := dialer.NetDialContext(ctx, "tcp", "test.limacharlie.io:443")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "proxy returned status 407")
+	assert.Nil(t, conn)
+}
+
+func TestInvalidProxyURL(t *testing.T) {
+	client := &Client{
+		options: ClientOptions{
+			ProxyURL: "://invalid-url",
+		},
+		wssURL: "wss://test.limacharlie.io/test",
+	}
+
+	dialer, err := client.createProxyDialer()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid proxy URL")
+	assert.Nil(t, dialer)
+}


### PR DESCRIPTION
## Summary
- Add support for connecting to LimaCharlie cloud through HTTP CONNECT proxies
- Add ProxyURL, ProxyUsername, and ProxyPassword fields to ClientOptions
- Implement automatic retry logic (3 retries) for proxy connections

## Implementation Details
- Created `createProxyDialer()` method that establishes HTTP CONNECT tunnel
- Supports HTTP Basic authentication for proxy servers
- Handles TLS/SSL negotiation after tunnel establishment
- Only affects WebSocket connections to LimaCharlie cloud

## Configuration
Proxy settings can be configured via:
- YAML/JSON configuration files
- Command-line parameters
- Environment variables

Example:
```yaml
client_options:
  proxy_url: "http://proxy.example.com:8080"
  proxy_username: "user"  # optional
  proxy_password: "pass"  # optional
```

## Test plan
- [ ] Test direct connection (no proxy)
- [ ] Test connection through proxy without authentication
- [ ] Test connection through proxy with authentication
- [ ] Test retry logic on proxy connection failures
- [ ] Verify TLS/SSL works correctly through proxy

🤖 Generated with Claude Code