### PR TITLE
Add ParsingGrok field to MappingDescriptor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,9 +5,11 @@ go 1.24
 toolchain go1.24.4
 
 require (
+	github.com/elastic/go-grok v0.3.1
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/refractionPOINT/go-limacharlie/limacharlie v0.0.0-20250606003539-fa833c32796e
+	github.com/stretchr/testify v1.10.0
 	github.com/vmihailenco/msgpack/v5 v5.4.1
 )
 
@@ -35,13 +37,13 @@ require (
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.6 // indirect
 	github.com/googleapis/gax-go/v2 v2.14.2 // indirect
+	github.com/magefile/mage v1.15.0 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rs/zerolog v1.34.0 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.5.0 // indirect
-	github.com/stretchr/testify v1.10.0 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
 	github.com/zeebo/errs v1.4.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ github.com/cncf/xds/go v0.0.0-20250501225837-2ac532fd4443/go.mod h1:W+zGtBO5Y1Ig
 github.com/coreos/go-systemd/v22 v22.5.0/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/elastic/go-grok v0.3.1 h1:WEhUxe2KrwycMnlvMimJXvzRa7DoByJB4PVUIE1ZD/U=
+github.com/elastic/go-grok v0.3.1/go.mod h1:n38ls8ZgOboZRgKcjMY8eFeZFMmcL9n2lP0iHhIDk64=
 github.com/envoyproxy/go-control-plane v0.13.4 h1:zEqyPVyku6IvWCFwux4x9RxkLOMUL+1vC9xUFv5l2/M=
 github.com/envoyproxy/go-control-plane v0.13.4/go.mod h1:kDfuBlDVsSj2MjrLEtRWtHlsWIFcGyB2RMO44Dc5GZA=
 github.com/envoyproxy/go-control-plane/envoy v1.32.4 h1:jb83lalDRZSpPWW2Z7Mck/8kXZ5CQAFYVjQcdVIr83A=
@@ -73,6 +75,8 @@ github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/magefile/mage v1.15.0 h1:BvGheCMAsG3bWUDbZ8AyXXpCNwU9u5CB6sM+HNb9HYg=
+github.com/magefile/mage v1.15.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHPsaIE=
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=

--- a/protocol/mapping.go
+++ b/protocol/mapping.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"regexp"
 	"strconv"
+
+	"github.com/elastic/go-grok"
 )
 
 // Whenever a value references a "Path", it means the value is a
@@ -19,6 +21,9 @@ type MappingDescriptor struct {
 	// Use the named capture groups from the regular
 	// expression below to parse text lines into JSON.
 	ParsingRE string `json:"parsing_re,omitempty" yaml:"parsing_re,omitempty"`
+
+	// Grok patterns to parse events where 'message' is the root field.
+	ParsingGrok map[string]string `json:"parsing_grok,omitempty" yaml:"parsing_grok,omitempty"`
 
 	// Path to the component of the JSON events that
 	// indicates unique values to become Sensor IDs.
@@ -109,6 +114,12 @@ func (md *MappingDescriptor) UnmarshalJSON(data []byte) error {
 func (d MappingDescriptor) Validate() error {
 	if d.ParsingRE != "" {
 		if _, err := regexp.Compile(d.ParsingRE); err != nil {
+			return err
+		}
+	}
+	if len(d.ParsingGrok) > 0 {
+		g := grok.New()
+		if err := g.AddPatterns(d.ParsingGrok); err != nil {
 			return err
 		}
 	}

--- a/protocol/mapping_test.go
+++ b/protocol/mapping_test.go
@@ -1,0 +1,136 @@
+package protocol
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMappingDescriptor_Validate(t *testing.T) {
+	tests := []struct {
+		name    string
+		mapping MappingDescriptor
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "empty mapping is valid",
+			mapping: MappingDescriptor{},
+			wantErr: false,
+		},
+		{
+			name: "valid ParsingRE",
+			mapping: MappingDescriptor{
+				ParsingRE: `(?P<timestamp>\d{4}-\d{2}-\d{2}) (?P<message>.*)`,
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid ParsingRE",
+			mapping: MappingDescriptor{
+				ParsingRE: `(?P<timestamp>\d{4}-\d{2}-\d{2}) (?P<message>.*`,
+			},
+			wantErr: true,
+			errMsg:  "error parsing regexp",
+		},
+		{
+			name: "valid ParsingGrok with simple patterns",
+			mapping: MappingDescriptor{
+				ParsingGrok: map[string]string{
+					"USERNAME": `[a-zA-Z0-9._-]+`,
+					"USER":     `%{USERNAME}`,
+					"message":  `User %{USER:user} logged in`,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid ParsingGrok with complex patterns",
+			mapping: MappingDescriptor{
+				ParsingGrok: map[string]string{
+					"LOGLEVEL": "DEBUG|INFO|WARN|ERROR|FATAL",
+					"APPNAME":  "[a-zA-Z0-9._-]+",
+					"APPLOG":   `%{TIMESTAMP_ISO8601:timestamp} \[%{LOGLEVEL:level}\] \[%{APPNAME:app}\] %{GREEDYDATA:log_message}`,
+					"message":  "%{APPLOG}",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid ParsingGrok with alternation",
+			mapping: MappingDescriptor{
+				ParsingGrok: map[string]string{
+					"NGINX_ACCESS": `%{IPORHOST:client_ip} - %{USER:ident} \[%{HTTPDATE:timestamp}\] "%{WORD:method} %{DATA:request} HTTP/%{NUMBER:http_version}" %{INT:status} %{INT:bytes}`,
+					"SYSLOG_MSG":   `%{SYSLOGTIMESTAMP:timestamp} %{SYSLOGHOST:host} %{PROG:program}: %{GREEDYDATA:log_message}`,
+					"message":      "(%{NGINX_ACCESS}|%{SYSLOG_MSG})",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid ParsingGrok - pattern name with colon",
+			mapping: MappingDescriptor{
+				ParsingGrok: map[string]string{
+					"BAD:NAME": "test pattern",
+					"message":  "%{BAD:NAME}",
+				},
+			},
+			wantErr: true,
+			errMsg:  "name contains unsupported character ':'",
+		},
+		{
+			name: "invalid ParsingGrok - empty pattern name",
+			mapping: MappingDescriptor{
+				ParsingGrok: map[string]string{
+					"": "test pattern",
+				},
+			},
+			wantErr: false, // AddPatterns allows empty names
+		},
+		{
+			name: "both ParsingRE and ParsingGrok valid",
+			mapping: MappingDescriptor{
+				ParsingRE: `(?P<timestamp>\d{4}-\d{2}-\d{2}) (?P<message>.*)`,
+				ParsingGrok: map[string]string{
+					"USERNAME": `[a-zA-Z0-9._-]+`,
+					"message":  `User %{USERNAME:user} logged in`,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "empty ParsingGrok map is valid",
+			mapping: MappingDescriptor{
+				ParsingGrok: map[string]string{},
+			},
+			wantErr: false,
+		},
+		{
+			name: "ParsingGrok with nested patterns",
+			mapping: MappingDescriptor{
+				ParsingGrok: map[string]string{
+					"IPV4":       `(?:[0-9]{1,3}\.){3}[0-9]{1,3}`,
+					"HOSTNAME":   `[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*`,
+					"IPORHOST":   `(?:%{IPV4}|%{HOSTNAME})`,
+					"NGINX_HOST": `(?:%{IPORHOST:destination.ip})(:%{INT:destination.port})?`,
+					"message":    `Connection from %{NGINX_HOST}`,
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.mapping.Validate()
+			if tt.wantErr {
+				assert.Error(t, err, "expected validation error")
+				if tt.errMsg != "" {
+					assert.Contains(t, err.Error(), tt.errMsg, "error message should contain expected text")
+				}
+			} else {
+				assert.NoError(t, err, "expected no validation error")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Added new `ParsingGrok` field to MappingDescriptor struct for Grok pattern parsing support
- Integrated github.com/elastic/go-grok package for Grok expression validation
- Patterns will parse events assuming 'message' is the root field

## Changes
- Added `ParsingGrok map[string]string` field to MappingDescriptor
- Updated Validate() method to validate Grok patterns using go-grok library
- Added github.com/elastic/go-grok dependency
- Added comprehensive unit tests for the new functionality

## Example Usage

Here's an example configuration file showing how to use the new `ParsingGrok` field:

```yaml
client_options:
  hostname: "my-grok-adapter"
  platform: "grok"
  architecture: "parser"
  mapping:
    parsing_grok:
      # Custom patterns for parsing application logs
      LOGLEVEL: "DEBUG|INFO|WARN|ERROR|FATAL"
      APPNAME: "[a-zA-Z0-9._-]+"
      THREAD: "[a-zA-Z0-9._-]+"
      
      # Pattern definitions
      APPLOG: "%{TIMESTAMP_ISO8601:timestamp} \\[%{LOGLEVEL:level}\\] \\[%{APPNAME:app}\\] \\[%{THREAD:thread}\\] %{GREEDYDATA:log_message}"
      NGINX_ACCESS: '%{IPORHOST:client_ip} - %{USER:ident} \\[%{HTTPDATE:timestamp}\\] "%{WORD:method} %{DATA:request} HTTP/%{NUMBER:http_version}" %{INT:status} %{INT:bytes} "%{DATA:referrer}" "%{DATA:user_agent}"'
      SYSLOG_MSG: '%{SYSLOGTIMESTAMP:timestamp} %{SYSLOGHOST:host} %{PROG:program}(?:\\[%{POSINT:pid}\\])?: %{GREEDYDATA:log_message}'
      
      # Root pattern that will be applied to the 'message' field
      message: "(%{APPLOG}|%{NGINX_ACCESS}|%{SYSLOG_MSG})"
    
    sensor_key_path: "host"
    sensor_hostname_path: "host"
    event_type_path: "program"
    event_time_path: "timestamp"
```

With this configuration, the adapter will apply the root `message` pattern to parse incoming log messages. The pattern tries to match against multiple log formats (APPLOG, NGINX_ACCESS, or SYSLOG_MSG). The patterns are validated when the client starts up, ensuring they compile correctly before any parsing occurs.

## Test plan
- [x] Unit tests pass
- [x] Grok pattern validation works correctly
- [x] Invalid Grok patterns are properly rejected during validation
- [x] Example patterns compile successfully

🤖 Generated with [Claude Code](https://claude.ai/code)